### PR TITLE
Deploy dbt docs to GitHub Pages

### DIFF
--- a/.github/workflows/dbt-ci.yml
+++ b/.github/workflows/dbt-ci.yml
@@ -15,9 +15,11 @@ on:
       - '.github/workflows/dbt-ci.yml'
 
 permissions:
-  contents: read
+  contents: write  # Needed to deploy to GitHub Pages
   pull-requests: write
   issues: write
+  pages: write     # Needed for GitHub Pages deployment
+  id-token: write  # Needed for GitHub OIDC
 
 jobs:
   dbt-test:


### PR DESCRIPTION
Adds automatic deployment of dbt documentation to GitHub Pages for easy access.

**Changes:**
- Deploy docs on every push to main
- Fix GitHub Pages deployment permissions
- Add helpful URL in CI logs

**Result:**
- Docs available at: https://Data-Science-Link.github.io/fentanyl-awareness/
- Updates automatically with every main push

**Setup Required:**
Enable GitHub Pages after merge in Settings → Pages (Deploy from branch: gh-pages)