### PR TITLE
Remove stale cdc_wonder_raw source from dbt project

### DIFF
--- a/data_engineering/data_build_tool/dbt/models/schema.yml
+++ b/data_engineering/data_build_tool/dbt/models/schema.yml
@@ -1,17 +1,6 @@
 version: 2
 
 sources:
-  - name: cdc_wonder_raw
-    description: "Raw CDC WONDER synthetic opioid mortality data"
-    schema: main
-    tables:
-      - name: provisional_mortality_statistics_2018_through_last_week_manual_download
-        description: "Provisional mortality data from 2018-current (manual download)"
-      - name: multiple_cause_of_death_1999_2020_manual_download
-        description: "Multiple cause of death data from 1999-2020 (manual download)"
-      - name: multiple_cause_of_death_2018_2023_single_race_manual_download
-        description: "Multiple cause of death data from 2018-2023, single race (manual download)"
-
   - name: cdc_api_raw
     description: "Raw CDC SODA API drug overdose data"
     schema: main


### PR DESCRIPTION
Removed the obsolete `cdc_wonder_raw` source definition from the dbt configuration to prevent it from appearing in the project documentation. Verified the fix by confirming successful project compilation, passing all 19 data tests, and ensuring the source is absent from generated dbt artifacts (`manifest.json` and `catalog.json`).

Fixes #19

---
*PR created automatically by Jules for task [14620534247506123788](https://jules.google.com/task/14620534247506123788) started by @Data-Science-Link*