### PR TITLE
Remove Deprecated CDC WONDER Sources and Documentation References

### DIFF
--- a/data_engineering/README.md
+++ b/data_engineering/README.md
@@ -88,21 +88,21 @@ duckdb data_build_tool/fentanyl_awareness.duckdb
 .tables
 
 # Explore raw data
-SELECT * FROM main.d176_provisional_2018_current LIMIT 5;
+SELECT * FROM main.cdc_api_provisional_overdose_counts LIMIT 5;
 
 # Query cleaned staging data (after dbt run)
-SELECT * FROM main.stg_cdc_wonder_fentanyl_deaths_provisional_2018_current LIMIT 5;
+SELECT * FROM main.stg_cdc_api_provisional_overdose_counts LIMIT 5;
 
 # Top states by deaths
-SELECT residence_state, SUM(deaths) as total_deaths
-FROM main.stg_cdc_wonder_fentanyl_deaths_provisional_2018_current
-GROUP BY residence_state
+SELECT state, SUM(rolling_12_month_deaths) as total_deaths
+FROM main.stg_cdc_api_provisional_overdose_counts
+GROUP BY state
 ORDER BY total_deaths DESC
 LIMIT 10;
 
 # Export results to CSV
 .output results.csv
-SELECT * FROM main.stg_cdc_wonder_fentanyl_deaths_provisional_2018_current;
+SELECT * FROM main.stg_cdc_api_provisional_overdose_counts;
 .output stdout
 ```
 
@@ -132,9 +132,7 @@ The seed files are automatically loaded when you run `dbt seed`.
 ### Available dbt Models
 
 **Staging Models**:
-- `stg_cdc_wonder_fentanyl_deaths_final_1999_2020` - Historical CDC data
-- `stg_cdc_wonder_fentanyl_deaths_final_2018_2023` - Recent CDC data
-- `stg_cdc_wonder_fentanyl_deaths_provisional_2018_current` - Provisional data
+- `stg_cdc_api_provisional_overdose_counts` - Provisional drug overdose death counts from CDC API
 - `stg_census_state_population` - Population estimates
 - `stg_census_state_economic` - Economic indicators
 

--- a/data_engineering/data_build_tool/README.md
+++ b/data_engineering/data_build_tool/README.md
@@ -57,9 +57,7 @@ dbt docs serve
 ## 📊 Data Models
 
 ### Staging Models
-- `stg_cdc_wonder_fentanyl_deaths_final_1999_2020` - Historical CDC data
-- `stg_cdc_wonder_fentanyl_deaths_final_2018_2023` - Recent CDC data
-- `stg_cdc_wonder_fentanyl_deaths_provisional_2018_current` - Provisional data
+- `stg_cdc_api_provisional_overdose_counts` - Provisional drug overdose death counts from CDC API
 - `stg_census_state_population` - Population estimates
 - `stg_census_state_economic` - Economic indicators
 
@@ -85,7 +83,7 @@ Defines external package dependencies:
 ```
 Raw Data Sources → Seeds → Staging Models → Mart Models → Final Dataset
      ↓               ↓           ↓              ↓            ↓
-CDC WONDER      → CSV Files → Cleaned Data → Analytics → CSV Export
+CDC SODA API    → Seeds     → Cleaned Data → Analytics → CSV Export
 Census Data     → Seeds     → Validated    → Combined  → Google Sheets
 Other Sources  → Raw Data  → Standardized → Enriched  → Final Output
 ```

--- a/data_engineering/data_build_tool/dbt/models/schema.yml
+++ b/data_engineering/data_build_tool/dbt/models/schema.yml
@@ -1,17 +1,6 @@
 version: 2
 
 sources:
-  - name: cdc_wonder_raw
-    description: "Raw CDC WONDER synthetic opioid mortality data"
-    schema: main
-    tables:
-      - name: provisional_mortality_statistics_2018_through_last_week_manual_download
-        description: "Provisional mortality data from 2018-current (manual download)"
-      - name: multiple_cause_of_death_1999_2020_manual_download
-        description: "Multiple cause of death data from 1999-2020 (manual download)"
-      - name: multiple_cause_of_death_2018_2023_single_race_manual_download
-        description: "Multiple cause of death data from 2018-2023, single race (manual download)"
-
   - name: cdc_api_raw
     description: "Raw CDC SODA API drug overdose data"
     schema: main


### PR DESCRIPTION
I have removed the deprecated `cdc_wonder_raw` source from the dbt configuration and purged all references to `stg_cdc_wonder_*` models from the project documentation. This ensures that the dbt documentation and lineage graph no longer display these legacy components. I also updated the documentation to accurately reflect the current pipeline which uses the CDC SODA API as its primary data source, including updated sample queries and data flow diagrams.

Fixes #25

---
*PR created automatically by Jules for task [12061472182211871214](https://jules.google.com/task/12061472182211871214) started by @Data-Science-Link*