### PR TITLE
Fix Broken Census Data Refresh and Improve Pipeline Robustness

### DIFF
--- a/.github/workflows/weekly-data-refresh.yml
+++ b/.github/workflows/weekly-data-refresh.yml
@@ -40,13 +40,26 @@ jobs:
         pip install -r requirements.txt
         pip install dbt-core dbt-duckdb
 
-    - name: 🔄 Extract Latest Data
-      env:
-        CENSUS_API_KEY: ${{ secrets.CENSUS_API_KEY }}
+    - name: 📥 Extract CDC SODA Data
       run: |
         echo "📥 Extracting CDC SODA API data..."
         python data_engineering/data_sources/cdc_api/soda_extractor.py
 
+    - name: 🔑 Check for Census API Key
+      id: check_key
+      run: |
+        if [ -z "${{ secrets.CENSUS_API_KEY }}" ]; then
+          echo "⚠️ WARNING: CENSUS_API_KEY is missing. Census data extraction will be skipped."
+          echo "has_key=false" >> $GITHUB_OUTPUT
+        else
+          echo "has_key=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: 📥 Extract US Census Data
+      if: steps.check_key.outputs.has_key == 'true'
+      env:
+        CENSUS_API_KEY: ${{ secrets.CENSUS_API_KEY }}
+      run: |
         echo "📥 Extracting US Census demographic data..."
         python data_engineering/data_sources/census_acs/census_extractor.py
 

--- a/data_engineering/data_sources/census_acs/census_extractor.py
+++ b/data_engineering/data_sources/census_acs/census_extractor.py
@@ -61,14 +61,15 @@ class CensusExtractor:
         Extract state-level population estimates from ACS
 
         Args:
-            years: List of years to extract (default: 2005 to current year)
+            years: List of years to extract (default: 2009 to current year)
 
         Returns:
             DataFrame with state population data
         """
         if years is None:
             current_year = datetime.now().year
-            years = list(range(2005, current_year + 1))
+            # ACS 5-year estimates started in 2009
+            years = list(range(2009, current_year + 1))
 
         logger.info(f"Extracting state population estimates for years: {years}")
 
@@ -97,7 +98,17 @@ class CensusExtractor:
 
                 response.raise_for_status()
 
-                data = response.json()
+                # Check if the response is actually JSON
+                if 'application/json' not in response.headers.get('Content-Type', ''):
+                    logger.error(f"Error fetching data for year {year}: Expected JSON but received {response.headers.get('Content-Type')}. "
+                                 f"This often indicates a missing API key or an invalid endpoint.")
+                    continue
+
+                try:
+                    data = response.json()
+                except Exception as e:
+                    logger.error(f"Error parsing JSON for year {year}: {e}")
+                    continue
 
                 # Convert to DataFrame
                 df = pd.DataFrame(data[1:], columns=data[0])
@@ -166,7 +177,17 @@ class CensusExtractor:
 
                 response.raise_for_status()
 
-                data = response.json()
+                # Check if the response is actually JSON
+                if 'application/json' not in response.headers.get('Content-Type', ''):
+                    logger.error(f"Error fetching economic data for year {year}: Expected JSON but received {response.headers.get('Content-Type')}. "
+                                 f"This often indicates a missing API key or an invalid endpoint.")
+                    continue
+
+                try:
+                    data = response.json()
+                except Exception as e:
+                    logger.error(f"Error parsing economic JSON for year {year}: {e}")
+                    continue
 
                 # Convert to DataFrame
                 df = pd.DataFrame(data[1:], columns=data[0])


### PR DESCRIPTION
This PR fixes the broken weekly data refresh by making the Census data extraction more resilient and preventing workflow failures when the Census API key is missing or when the API returns unexpected HTML error pages.

Key changes:
1.  **`census_extractor.py`**:
    *   Adjusted the default start year to 2009, which is the actual start of the ACS 5-year estimates.
    *   Added `Content-Type` validation to ensure responses are JSON before parsing.
    *   Wrapped JSON parsing in `try-except` to gracefully handle the "Expecting value" error caused by HTML redirects (usually due to missing keys).
2.  **GitHub Workflow**:
    *   Separated data extraction steps.
    *   Added a conditional check for the `CENSUS_API_KEY` secret.
    *   The workflow now issues a warning and skips Census extraction if the key is missing, rather than failing the entire run.

These changes were verified by running the script locally (reproducing and then fixing the error) and executing the full dbt pipeline (`seed`, `run`, `test`) to ensure no regressions.

Fixes #30

---
*PR created automatically by Jules for task [16953579994051568938](https://jules.google.com/task/16953579994051568938) started by @Data-Science-Link*