### PR TITLE
Fix iframe height on tab switch

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -261,8 +261,22 @@
             });
 
             // Fix iframe height on tab switch
+            function resizeIframe() {
+                const iframe = $('#docs iframe');
+                if (iframe.length) {
+                    const newHeight = Math.max(800, window.innerHeight - 250);
+                    iframe.css('height', newHeight + 'px');
+                }
+            }
+
             $('#docs-tab').on('shown.bs.tab', function (e) {
-                // Potential to auto-resize iframe if needed
+                resizeIframe();
+            });
+
+            $(window).resize(function() {
+                if ($('#docs-tab').hasClass('active')) {
+                    resizeIframe();
+                }
             });
         });
     </script>


### PR DESCRIPTION
Implemented auto-resizing of the dbt docs iframe when the pipeline docs tab is shown. Added a listener on the window resize event to maintain the calculated iframe height.

---
*PR created automatically by Jules for task [17669007745827943518](https://jules.google.com/task/17669007745827943518) started by @Data-Science-Link*