### PR TITLE
🧹 Remove unused `os` import from `soda_extractor.py`

### DIFF
--- a/data_engineering/data_sources/cdc_api/soda_extractor.py
+++ b/data_engineering/data_sources/cdc_api/soda_extractor.py
@@ -7,7 +7,6 @@ Specifically, it extracts data for "Synthetic opioids, excl. methadone (T40.4)".
 The data is saved as a CSV file in the dbt seeds directory.
 """
 
-import os
 import requests
 import pandas as pd
 from pathlib import Path


### PR DESCRIPTION
🎯 **What:** Removed the unused `os` import in `data_engineering/data_sources/cdc_api/soda_extractor.py`.
💡 **Why:** This improves maintainability and code readability by removing dead code.
✅ **Verification:** Ran `python data_engineering/data_sources/cdc_api/soda_extractor.py` and the full `dbt test` suite; no regressions were introduced.
✨ **Result:** A cleaner file without unneeded dependencies.

---
*PR created automatically by Jules for task [13238340072925599529](https://jules.google.com/task/13238340072925599529) started by @Data-Science-Link*