### PR TITLE
🔒 Fix potential API key exposure in logs

### DIFF
--- a/data_engineering/data_sources/census_acs/census_extractor.py
+++ b/data_engineering/data_sources/census_acs/census_extractor.py
@@ -56,6 +56,13 @@ class CensusExtractor:
             'User-Agent': 'Fentanyl-Awareness-Pipeline/1.0'
         })
 
+    def _sanitize_error(self, e: Exception) -> str:
+        """Sanitize error messages to prevent leaking API keys."""
+        error_msg = str(e)
+        if self.api_key:
+            error_msg = error_msg.replace(self.api_key, "***REDACTED***")
+        return error_msg
+
     def get_state_population_estimates(self, years: List[int] = None) -> pd.DataFrame:
         """
         Extract state-level population estimates from ACS
@@ -107,7 +114,7 @@ class CensusExtractor:
                 try:
                     data = response.json()
                 except Exception as e:
-                    logger.error(f"Error parsing JSON for year {year}: {e}")
+                    logger.error(f"Error parsing JSON for year {year}: {self._sanitize_error(e)}")
                     continue
 
                 # Convert to DataFrame
@@ -121,7 +128,7 @@ class CensusExtractor:
                 time.sleep(RATE_LIMITS["delay_between_requests"])
 
             except Exception as e:
-                logger.error(f"Error fetching data for year {year}: {e}")
+                logger.error(f"Error fetching data for year {year}: {self._sanitize_error(e)}")
                 continue
 
         if not all_data:
@@ -186,7 +193,7 @@ class CensusExtractor:
                 try:
                     data = response.json()
                 except Exception as e:
-                    logger.error(f"Error parsing economic JSON for year {year}: {e}")
+                    logger.error(f"Error parsing economic JSON for year {year}: {self._sanitize_error(e)}")
                     continue
 
                 # Convert to DataFrame
@@ -200,7 +207,7 @@ class CensusExtractor:
                 time.sleep(RATE_LIMITS["delay_between_requests"])
 
             except Exception as e:
-                logger.error(f"Error fetching economic data for year {year}: {e}")
+                logger.error(f"Error fetching economic data for year {year}: {self._sanitize_error(e)}")
                 continue
 
         if not all_data:
@@ -296,7 +303,11 @@ def test_census_api():
         return True
 
     except Exception as e:
-        print(f"❌ Error during test: {e}")
+        error_msg = str(e)
+        api_key = os.getenv('CENSUS_API_KEY')
+        if api_key:
+            error_msg = error_msg.replace(api_key, "***REDACTED***")
+        print(f"❌ Error during test: {error_msg}")
         return False
 
 def main():
@@ -342,7 +353,11 @@ def main():
         print(f"States covered: {population_df['state_name'].nunique()}")
 
     except Exception as e:
-        logger.error(f"Error in main execution: {e}")
+        error_msg = str(e)
+        api_key = os.getenv('CENSUS_API_KEY')
+        if api_key:
+            error_msg = error_msg.replace(api_key, "***REDACTED***")
+        logger.error(f"Error in main execution: {error_msg}")
         return 1
 
     return 0

--- a/test_redaction.py
+++ b/test_redaction.py
@@ -1,0 +1,15 @@
+from data_engineering.data_sources.census_acs.census_extractor import CensusExtractor
+import os
+import requests
+
+os.environ['CENSUS_API_KEY'] = 'SUPER_SECRET_KEY'
+extractor = CensusExtractor()
+assert extractor.api_key == 'SUPER_SECRET_KEY'
+try:
+    raise requests.exceptions.HTTPError("Failed to fetch from https://api.census.gov/data/2021/acs/acs5?get=NAME&for=state:*&key=SUPER_SECRET_KEY")
+except Exception as e:
+    sanitized = extractor._sanitize_error(e)
+    assert 'SUPER_SECRET_KEY' not in sanitized
+    assert '***REDACTED***' in sanitized
+    print("Sanitized error:", sanitized)
+    print("Test passed.")


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was a potential sensitive data exposure where the `CENSUS_API_KEY` could be leaked into application logs.

⚠️ **Risk:** When `requests` raises an exception (such as `requests.exceptions.HTTPError`), the string representation of that error can contain the full URL being requested. Because the Census API requires passing the API key as a query parameter (`?key=...`), this key would be included in the error string. Because `census_extractor.py` caught broad exceptions and logged them directly (`logger.error(f"Error... {e}")`), any error would write the raw API key into the logs, exposing credentials.

🛡️ **Solution:** Implemented a `_sanitize_error` helper method that checks if the `CENSUS_API_KEY` is set and, if so, replaces any occurrence of it in the exception's string representation with `"***REDACTED***"`. This helper is now applied to all broad exception logging throughout `census_extractor.py`, ensuring safe logs without breaking any existing functionality.

---
*PR created automatically by Jules for task [3309317582718137880](https://jules.google.com/task/3309317582718137880) started by @Data-Science-Link*